### PR TITLE
Use native keyboard events

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -1,10 +1,13 @@
 /**
  * Created by andrewhurst on 10/5/15.
  */
-var React = require('react-native'),
-    KeyboardEvents = require('react-native-keyboardevents'),
-    KeyboardEventEmitter = KeyboardEvents.Emitter;
-var { View, LayoutAnimation } = React;
+var React = require('react-native');
+
+var {
+    DeviceEventEmitter,
+    LayoutAnimation,
+    View
+} = React;
 
 // From: https://medium.com/man-moon/writing-modern-react-native-ui-e317ff956f02
 const animations = {
@@ -39,7 +42,8 @@ class KeyboardSpacer extends React.Component {
     constructor(props, context) {
         super(props, context);
         this.state = {
-            keyboardSpace: 0
+            keyboardSpace: 0,
+            isKeyboardOpened: false
         };
 
         this.updateKeyboardSpace = this.updateKeyboardSpace.bind(this);
@@ -68,13 +72,16 @@ class KeyboardSpacer extends React.Component {
     }
 
     componentDidMount() {
-        KeyboardEventEmitter.on(KeyboardEvents.KeyboardDidShowEvent, this.updateKeyboardSpace);
-        KeyboardEventEmitter.on(KeyboardEvents.KeyboardWillHideEvent, this.resetKeyboardSpace);
+        this._listeners = [
+            DeviceEventEmitter.addListener('keyboardDidShow', this.updateKeyboardSpace),
+            DeviceEventEmitter.addListener('keyboardWillHide', this.resetKeyboardSpace)
+        ];
     }
 
     componentWillUnmount() {
-        KeyboardEventEmitter.off(KeyboardEvents.KeyboardDidShowEvent, this.updateKeyboardSpace);
-        KeyboardEventEmitter.off(KeyboardEvents.KeyboardWillHideEvent, this.resetKeyboardSpace);
+        this._listeners.forEach(function(/** EmitterSubscription */listener) {
+            listener.remove();
+        });
     }
 
     render() {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,12 @@
     "spacer"
   ],
   "peerDependencies": {
-    "react-native": ">=0.5"
+    "react-native": ">=0.11"
   },
   "author": "Andrew Hurst",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer/issues"
   },
-  "homepage": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer#readme",
-  "dependencies": {
-    "react-native-keyboardevents": "^0.4.5"
-  }
+  "homepage": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer#readme"
 }


### PR DESCRIPTION
react-native 0.11+ supports keyboard events without external plugins
https://github.com/facebook/react-native/releases/tag/v0.11.0-rc
