### PR TITLE
Use keyboardDidShow/keyboardDidHide events for android

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -6,7 +6,8 @@ var React = require('react-native');
 var {
     DeviceEventEmitter,
     LayoutAnimation,
-    View
+    View, 
+    Platform
 } = React;
 
 // From: https://medium.com/man-moon/writing-modern-react-native-ui-e317ff956f02
@@ -72,10 +73,17 @@ class KeyboardSpacer extends React.Component {
     }
 
     componentDidMount() {
-        this._listeners = [
-            DeviceEventEmitter.addListener('keyboardWillShow', this.updateKeyboardSpace),
-            DeviceEventEmitter.addListener('keyboardWillHide', this.resetKeyboardSpace)
-        ];
+        if (Platform.OS == "android") {
+            this._listeners = [
+                DeviceEventEmitter.addListener('keyboardDidShow', this.updateKeyboardSpace),
+                DeviceEventEmitter.addListener('keyboardDidHide', this.resetKeyboardSpace)
+            ];            
+        } else {
+            this._listeners = [
+                DeviceEventEmitter.addListener('keyboardWillShow', this.updateKeyboardSpace),
+                DeviceEventEmitter.addListener('keyboardWillHide', this.resetKeyboardSpace)
+            ];
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
https://github.com/Andr3wHur5t/react-native-keyboard-spacer/issues/7

This will works since keyboardDidShow/keyboardDidHide events fires before android keyboard animation stops. We'll likely need to revisit this once https://github.com/facebook/react-native/issues/3468 is fixed.
