### PR TITLE
Add android Prop

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -61,10 +61,13 @@ export default class KeyboardSpacer extends Component {
     const updateListener = Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow';
     const resetListener = Platform.OS === 'android' ? 'keyboardDidHide' : 'keyboardWillHide';
     const listenAndroid = Platform.OS === 'android' && this.props.android;
-    (listenAndroid || Platform.OS === 'ios') && this._listeners = [
-      Keyboard.addListener(updateListener, this.updateKeyboardSpace),
-      Keyboard.addListener(resetListener, this.resetKeyboardSpace)
-    ];
+    const shouldListen = listenAndroid || Platform.OS === 'ios';
+    if (shouldListen) {
+      this._listeners = [
+        Keyboard.addListener(updateListener, this.updateKeyboardSpace),
+        Keyboard.addListener(resetListener, this.resetKeyboardSpace)
+      ];
+    }
   }
 
   componentWillUpdate(props, state) {

--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -62,7 +62,7 @@ class KeyboardSpacer extends React.Component {
     }
 
     componentDidMount() {
-        if (Platform.OS == "android") {
+        if (Platform.OS == "android" && this.props.android) {
             this._listeners = [
                 DeviceEventEmitter.addListener('keyboardDidShow', this.updateKeyboardSpace),
                 DeviceEventEmitter.addListener('keyboardDidHide', this.resetKeyboardSpace)
@@ -76,14 +76,18 @@ class KeyboardSpacer extends React.Component {
     }
 
     componentWillUnmount() {
-        this._listeners.forEach(function(/** EmitterSubscription */listener) {
+        this._listeners && this._listeners.forEach(function(/** EmitterSubscription */listener) {
             listener.remove();
         });
     }
 
     render() {
-        return (<View style={[{height: this.state.keyboardSpace, left: 0, right: 0, bottom: 0}, this.props.style]}/>);
+      if (Platform.OS === 'android' && !this.props.android) { return null; }
+
+      return (<View style={[{height: this.state.keyboardSpace, left: 0, right: 0, bottom: 0}, this.props.style]}/>);
     }
 }
+
+KeyboardSpacer.defaultProps = { android: true };
 
 module.exports = KeyboardSpacer;

--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -6,6 +6,7 @@ import {
   Keyboard,
   LayoutAnimation,
   View,
+  ViewPropTypes,
   Platform,
   StyleSheet
 } from 'react-native';
@@ -22,7 +23,7 @@ export default class KeyboardSpacer extends Component {
   static propTypes = {
     topSpacing: PropTypes.number,
     onToggle: PropTypes.func,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     animationConfig: PropTypes.object,
     android: PropTypes.bool,
   };

--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -60,7 +60,8 @@ export default class KeyboardSpacer extends Component {
   componentDidMount() {
     const updateListener = Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow';
     const resetListener = Platform.OS === 'android' ? 'keyboardDidHide' : 'keyboardWillHide';
-    this._listeners = [
+    const listenAndroid = Platform.OS === 'android' && this.props.android;
+    (listenAndroid || Platform.OS === 'ios') && this._listeners = [
       Keyboard.addListener(updateListener, this.updateKeyboardSpace),
       Keyboard.addListener(resetListener, this.resetKeyboardSpace)
     ];
@@ -73,7 +74,7 @@ export default class KeyboardSpacer extends Component {
   }
 
   componentWillUnmount() {
-    this._listeners.forEach(listener => listener.remove());
+    this._listeners && this._listeners.forEach(listener => listener.remove());
   }
 
   updateKeyboardSpace(frames) {
@@ -95,6 +96,9 @@ export default class KeyboardSpacer extends Component {
   }
 
   render() {
+    if (Platform.OS === 'android' && !this.props.android) {
+      return null;
+    }
     return (
       <View style={[styles.container, { height: this.state.keyboardSpace }, this.props.style]} />
     );

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ AppRegistry.registerComponent('DemoApp', () => DemoApp);
 | :------------ |:---------------:| :---------------:| :-----|
 | topSpacing | 0 | `number` | Add or subtract additional spacing from keyboard height |
 | animationConfig | [A default animation](https://github.com/Andr3wHur5t/react-native-keyboard-spacer/blob/expose-layout-animations/KeyboardSpacer.js#L14) | `LayoutAnimationConfig` | [LayoutAnimation](https://facebook.github.io/react-native/docs/layoutanimation.html#content) configuration object |
+| android | true | `boolean` | Whether the keyboard should be rendered on android or not (return a view or null) |
 
 ### Properties - Methods
 


### PR DESCRIPTION
on Android, I use the windowSoftInputMode to respond to keyboard visibility, and this does not go quite well with this spacer.
I've researched a bit and found nothing that could solve this issue on the Android side, so I added an android prop that defaults to true. If its false, on android the spacer will return null.
