### PR TITLE
Fix deprecate warning using the View.propTypes

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -8,7 +8,8 @@ import {
   View,
   Dimensions,
   Platform,
-  StyleSheet
+  StyleSheet,
+  ViewPropTypes
 } from 'react-native';
 
 const styles = StyleSheet.create({
@@ -37,7 +38,7 @@ export default class KeyboardSpacer extends Component {
   static propTypes = {
     topSpacing: PropTypes.number,
     onToggle: PropTypes.func,
-    style: View.propTypes.style,
+    style: (ViewPropTypes && ViewPropTypes.style) || View.propTypes.style,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Fix the deprecated warning generated by https://github.com/facebook/react-native/blob/a6df7a6ce7111e9f281007d80b3809d775928439/Libraries/Components/View/View.js#L183