### PR TITLE
Import PropTypes from 'prop-types' package

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -1,7 +1,8 @@
 /**
  * Created by andrewhurst on 10/5/15.
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Keyboard,
   LayoutAnimation,


### PR DESCRIPTION
React.PropTypes was removed in v16