### PR TITLE
Fixes crash using Release mode on RN 0.49

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -8,6 +8,7 @@ import {
   LayoutAnimation,
   View,
   Dimensions,
+  ViewPropTypes,
   Platform,
   StyleSheet
 } from 'react-native';
@@ -38,7 +39,7 @@ export default class KeyboardSpacer extends Component {
   static propTypes = {
     topSpacing: PropTypes.number,
     onToggle: PropTypes.func,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Because View.propTypes no longer exists in React Native 0.49, View.propTypes.style throws an exception for any app using React Native > 0.49.  Should use ViewPropTypes.style instead.

This doesn't happen in dev mode, only in release.  Dev mode I think just throws a warning.