### PR TITLE
Do not animate layout if keyboard state is not changed.

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -72,7 +72,7 @@ export default class KeyboardSpacer extends Component {
   }
 
   updateKeyboardSpace(event) {
-    if (!event.endCoordinates) {
+    if (!event.endCoordinates || this.state.isKeyboardOpened) {
       return;
     }
 
@@ -99,6 +99,10 @@ export default class KeyboardSpacer extends Component {
   }
 
   resetKeyboardSpace(event) {
+    if (!this.state.isKeyboardOpened) {
+      return;
+    }
+
     let animationConfig = defaultAnimation;
     if (Platform.OS === 'ios') {
       animationConfig = LayoutAnimation.create(


### PR DESCRIPTION
I've found that closing a modal cause keyboard to open and then immediately hide, which causes multiple calls of resetKeyboardSpace function, and this causes an error:
Warning: Overriding previous layout animation

Which affects Modal somehow, because it could not be hidden after this warning.