### PR TITLE
Update to make it work with react-native-web v12.0

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -39,7 +39,7 @@ export default class KeyboardSpacer extends Component {
   static propTypes = {
     topSpacing: PropTypes.number,
     onToggle: PropTypes.func,
-    style: ViewPropTypes.style,
+    style: ViewPropTypes && ViewPropTypes.style || PropTypes.object,
   };
 
   static defaultProps = {


### PR DESCRIPTION
ViewPropTypes is depreciated from react-native-web v12.0 upwards, this PR fixes it.