### PR TITLE
Fixed ViewPropTypes are deprecated

### DIFF
--- a/KeyboardSpacer.js
+++ b/KeyboardSpacer.js
@@ -8,10 +8,10 @@ import {
   LayoutAnimation,
   View,
   Dimensions,
-  ViewPropTypes,
   Platform,
   StyleSheet
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const styles = StyleSheet.create({
   container: {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer/issues"
   },
-  "homepage": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer#readme"
+  "homepage": "https://github.com/Andr3wHur5t/react-native-keyboard-spacer#readme",
+  "dependencies": {
+    "deprecated-react-native-prop-types": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Fix https://github.com/Andr3wHur5t/react-native-keyboard-spacer/issues/82
Fix https://github.com/Andr3wHur5t/react-native-keyboard-spacer/issues/84

Patch:
```
diff --git a/node_modules/react-native-keyboard-spacer/KeyboardSpacer.js b/node_modules/react-native-keyboard-spacer/KeyboardSpacer.js
index 14560d8..7ce3aca 100644
--- a/node_modules/react-native-keyboard-spacer/KeyboardSpacer.js
+++ b/node_modules/react-native-keyboard-spacer/KeyboardSpacer.js
@@ -8,10 +8,10 @@ import {
   LayoutAnimation,
   View,
   Dimensions,
-  ViewPropTypes,
   Platform,
   StyleSheet
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const styles = StyleSheet.create({
   container: {
```